### PR TITLE
fix jni4net and use apache Logger for the class CLRLoader

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Maven default annotation processors profile" enabled="true">
+        <sourceOutputDir name="target/generated-sources/annotations" />
+        <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
+        <outputRelativeToContentRoot value="true" />
+        <module name="jni4net.j" />
+        <module name="jni4net.n" />
+        <module name="jni4net.n.w32.v20" />
+        <module name="jni4net.n.w32.v40" />
+        <module name="jni4net.n.w64.v20" />
+        <module name="jni4net.n.w64.v40" />
+        <module name="jni4net.proxygen" />
+        <module name="jni4net.test.j" />
+        <module name="jni4net.test.n" />
+        <module name="jni4net.tested.j" />
+        <module name="jni4net.tested.n" />
+      </profile>
+    </annotationProcessing>
+    <bytecodeTargetLevel>
+      <module name="jni4net" target="1.5" />
+      <module name="jni4net.j" target="1.5" />
+      <module name="jni4net.n" target="1.5" />
+      <module name="jni4net.n.w32.v20" target="1.5" />
+      <module name="jni4net.n.w32.v40" target="1.5" />
+      <module name="jni4net.n.w64.v20" target="1.5" />
+      <module name="jni4net.n.w64.v40" target="1.5" />
+      <module name="jni4net.proxygen" target="1.5" />
+      <module name="jni4net.test.j" target="1.5" />
+      <module name="jni4net.test.n" target="1.5" />
+      <module name="jni4net.tested.j" target="1.5" />
+      <module name="jni4net.tested.n" target="1.5" />
+    </bytecodeTargetLevel>
+  </component>
+</project>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="file://$PROJECT_DIR$" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/jni4net.j" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/jni4net.n" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/jni4net.n.w32.v20" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/jni4net.n.w32.v40" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/jni4net.n.w64.v20" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/jni4net.n.w64.v40" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/jni4net.proxygen" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/jni4net.test.j" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/jni4net.test.n" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/jni4net.tested.j" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/jni4net.tested.n" charset="UTF-8" />
+  </component>
+</project>

--- a/.idea/libraries/Maven__junit_junit_4_5.xml
+++ b/.idea/libraries/Maven__junit_junit_4_5.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: junit:junit:4.5">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/junit/junit/4.5/junit-4.5.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/junit/junit/4.5/junit-4.5-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/junit/junit/4.5/junit-4.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__log4j_log4j_1_2_17.xml
+++ b/.idea/libraries/Maven__log4j_log4j_1_2_17.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: log4j:log4j:1.2.17">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/log4j/log4j/1.2.17/log4j-1.2.17.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/log4j/log4j/1.2.17/log4j-1.2.17-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/log4j/log4j/1.2.17/log4j-1.2.17-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MavenProjectsManager">
+    <option name="originalFiles">
+      <list>
+        <option value="$PROJECT_DIR$/pom.xml" />
+      </list>
+    </option>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/jni4net.iml" filepath="$PROJECT_DIR$/jni4net.iml" />
+      <module fileurl="file://$PROJECT_DIR$/jni4net.j/jni4net.j.iml" filepath="$PROJECT_DIR$/jni4net.j/jni4net.j.iml" />
+      <module fileurl="file://$PROJECT_DIR$/jni4net.n/jni4net.n.iml" filepath="$PROJECT_DIR$/jni4net.n/jni4net.n.iml" />
+      <module fileurl="file://$PROJECT_DIR$/jni4net.n.w32.v20/jni4net.n.w32.v20.iml" filepath="$PROJECT_DIR$/jni4net.n.w32.v20/jni4net.n.w32.v20.iml" />
+      <module fileurl="file://$PROJECT_DIR$/jni4net.n.w32.v40/jni4net.n.w32.v40.iml" filepath="$PROJECT_DIR$/jni4net.n.w32.v40/jni4net.n.w32.v40.iml" />
+      <module fileurl="file://$PROJECT_DIR$/jni4net.n.w64.v20/jni4net.n.w64.v20.iml" filepath="$PROJECT_DIR$/jni4net.n.w64.v20/jni4net.n.w64.v20.iml" />
+      <module fileurl="file://$PROJECT_DIR$/jni4net.n.w64.v40/jni4net.n.w64.v40.iml" filepath="$PROJECT_DIR$/jni4net.n.w64.v40/jni4net.n.w64.v40.iml" />
+      <module fileurl="file://$PROJECT_DIR$/jni4net.proxygen/jni4net.proxygen.iml" filepath="$PROJECT_DIR$/jni4net.proxygen/jni4net.proxygen.iml" />
+      <module fileurl="file://$PROJECT_DIR$/jni4net.test.j/jni4net.test.j.iml" filepath="$PROJECT_DIR$/jni4net.test.j/jni4net.test.j.iml" />
+      <module fileurl="file://$PROJECT_DIR$/jni4net.test.n/jni4net.test.n.iml" filepath="$PROJECT_DIR$/jni4net.test.n/jni4net.test.n.iml" />
+      <module fileurl="file://$PROJECT_DIR$/jni4net.tested.j/jni4net.tested.j.iml" filepath="$PROJECT_DIR$/jni4net.tested.j/jni4net.tested.j.iml" />
+      <module fileurl="file://$PROJECT_DIR$/jni4net.tested.n/jni4net.tested.n.iml" filepath="$PROJECT_DIR$/jni4net.tested.n/jni4net.tested.n.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,707 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="0bd9512f-5149-48e4-a3c5-0950e25b623b" name="Default" comment="">
+      <change type="NEW" beforePath="" afterPath="$PROJECT_DIR$/.idea/libraries/Maven__log4j_log4j_1_2_17.xml" />
+      <change type="DELETED" beforePath="$PROJECT_DIR$/jni4net.iml" afterPath="" />
+      <change type="DELETED" beforePath="$PROJECT_DIR$/jni4net.j/jni4net.j.iml" afterPath="" />
+      <change type="DELETED" beforePath="$PROJECT_DIR$/jni4net.n.w32.v20/jni4net.n.w32.v20.iml" afterPath="" />
+      <change type="DELETED" beforePath="$PROJECT_DIR$/jni4net.n.w32.v40/jni4net.n.w32.v40.iml" afterPath="" />
+      <change type="DELETED" beforePath="$PROJECT_DIR$/jni4net.n.w64.v20/jni4net.n.w64.v20.iml" afterPath="" />
+      <change type="DELETED" beforePath="$PROJECT_DIR$/jni4net.n.w64.v40/jni4net.n.w64.v40.iml" afterPath="" />
+      <change type="DELETED" beforePath="$PROJECT_DIR$/jni4net.n/jni4net.n.iml" afterPath="" />
+      <change type="DELETED" beforePath="$PROJECT_DIR$/jni4net.proxygen/jni4net.proxygen.iml" afterPath="" />
+      <change type="DELETED" beforePath="$PROJECT_DIR$/jni4net.test.j/jni4net.test.j.iml" afterPath="" />
+      <change type="DELETED" beforePath="$PROJECT_DIR$/jni4net.test.n/jni4net.test.n.iml" afterPath="" />
+      <change type="DELETED" beforePath="$PROJECT_DIR$/jni4net.tested.j/jni4net.tested.j.iml" afterPath="" />
+      <change type="DELETED" beforePath="$PROJECT_DIR$/jni4net.tested.n/jni4net.tested.n.iml" afterPath="" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/jni4net.j/pom.xml" afterPath="$PROJECT_DIR$/jni4net.j/pom.xml" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/jni4net.j/src/main/java/java_/lang/reflect/GenericDeclaration_.java" afterPath="$PROJECT_DIR$/jni4net.j/src/main/java/java_/lang/reflect/GenericDeclaration_.java" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/jni4net.j/src/main/java/java_/lang/reflect/TypeVariable_.java" afterPath="$PROJECT_DIR$/jni4net.j/src/main/java/java_/lang/reflect/TypeVariable_.java" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/jni4net.j/src/main/java/net/sf/jni4net/CLRLoader.java" afterPath="$PROJECT_DIR$/jni4net.j/src/main/java/net/sf/jni4net/CLRLoader.java" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/jni4net.n.w32.v20/pom.xml" afterPath="$PROJECT_DIR$/jni4net.n.w32.v20/pom.xml" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/jni4net.n.w32.v20/src/jni4net.n.w32.v20.csproj" afterPath="$PROJECT_DIR$/jni4net.n.w32.v20/src/jni4net.n.w32.v20.csproj" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/jni4net.n.w32.v40/pom.xml" afterPath="$PROJECT_DIR$/jni4net.n.w32.v40/pom.xml" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/jni4net.n.w32.v40/src/jni4net.n.w32.v40.csproj" afterPath="$PROJECT_DIR$/jni4net.n.w32.v40/src/jni4net.n.w32.v40.csproj" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/jni4net.n.w64.v20/pom.xml" afterPath="$PROJECT_DIR$/jni4net.n.w64.v20/pom.xml" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/jni4net.n.w64.v20/src/jni4net.n.w64.v20.csproj" afterPath="$PROJECT_DIR$/jni4net.n.w64.v20/src/jni4net.n.w64.v20.csproj" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/jni4net.n.w64.v40/pom.xml" afterPath="$PROJECT_DIR$/jni4net.n.w64.v40/pom.xml" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/jni4net.n.w64.v40/src/jni4net.n.w64.v40.csproj" afterPath="$PROJECT_DIR$/jni4net.n.w64.v40/src/jni4net.n.w64.v40.csproj" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/jni4net.test.n/pom.xml" afterPath="$PROJECT_DIR$/jni4net.test.n/pom.xml" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/pom.xml" afterPath="$PROJECT_DIR$/pom.xml" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/tools/keys/gennetkey.cmd" afterPath="$PROJECT_DIR$/tools/keys/gennetkey.cmd" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/tools/loadTools.cmd" afterPath="$PROJECT_DIR$/tools/loadTools.cmd" />
+    </list>
+    <ignored path="$PROJECT_DIR$/jni4net.n.w32.v20/target/" />
+    <ignored path="$PROJECT_DIR$/jni4net.n.w64.v20/target/" />
+    <ignored path="$PROJECT_DIR$/jni4net.j/target/" />
+    <ignored path="$PROJECT_DIR$/jni4net.test.j/target/" />
+    <ignored path="$PROJECT_DIR$/jni4net.n.w64.v40/target/" />
+    <ignored path="$PROJECT_DIR$/jni4net.proxygen/target/" />
+    <ignored path="$PROJECT_DIR$/jni4net.tested.n/target/" />
+    <ignored path="$PROJECT_DIR$/jni4net.n/target/" />
+    <ignored path="$PROJECT_DIR$/jni4net.test.n/target/" />
+    <ignored path="$PROJECT_DIR$/jni4net.tested.j/target/" />
+    <ignored path="$PROJECT_DIR$/target/" />
+    <ignored path="$PROJECT_DIR$/jni4net.n.w32.v40/target/" />
+    <option name="EXCLUDED_CONVERTED_TO_IGNORED" value="true" />
+    <option name="TRACKING_ENABLED" value="true" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="FileEditorManager">
+    <leaf SIDE_TABS_SIZE_LIMIT_KEY="300">
+      <file leaf-file-name="pom.xml" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/pom.xml">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="272">
+              <caret line="25" column="14" lean-forward="false" selection-start-line="25" selection-start-column="14" selection-end-line="25" selection-end-column="14" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="pom.xml" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/jni4net.j/pom.xml">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="323">
+              <caret line="19" column="21" lean-forward="false" selection-start-line="19" selection-start-column="21" selection-end-line="19" selection-end-column="21" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="CLRLoader.java" pinned="false" current-in-tab="true">
+        <entry file="file://$PROJECT_DIR$/jni4net.j/src/main/java/net/sf/jni4net/CLRLoader.java">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="374">
+              <caret line="45" column="36" lean-forward="true" selection-start-line="45" selection-start-column="36" selection-end-line="45" selection-end-column="36" />
+              <folding>
+                <element signature="imports" expanded="true" />
+              </folding>
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="Bridge.java" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/jni4net.j/src/main/java/net/sf/jni4net/Bridge.java">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="231">
+              <caret line="32" column="0" lean-forward="true" selection-start-line="32" selection-start-column="0" selection-end-line="32" selection-end-column="0" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="jni4net.properties" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/jni4net.j/src/main/filtered-resources/META-INF/jni4net.properties">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="0">
+              <caret line="0" column="30" lean-forward="false" selection-start-line="0" selection-start-column="17" selection-end-line="0" selection-end-column="35" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="pom.xml" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/jni4net.tested.n/pom.xml">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="119">
+              <caret line="7" column="13" lean-forward="true" selection-start-line="7" selection-start-column="13" selection-end-line="7" selection-end-column="13" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="TestClr.java" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/jni4net.test.j/src/test/java/net/sf/jni4net/test/TestClr.java">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="170">
+              <caret line="44" column="8" lean-forward="false" selection-start-line="44" selection-start-column="8" selection-end-line="44" selection-end-column="8" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+    </leaf>
+  </component>
+  <component name="FindInProjectRecents">
+    <findStrings>
+      <find>0.2.6.0</find>
+      <find>0.2.5.0</find>
+      <find>nunit</find>
+      <find>2.5.8</find>
+      <find>env.ProgramFiles</find>
+      <find>nuni</find>
+      <find>System.out</find>
+      <find>findDefaultDll</find>
+      <find>initi</find>
+      <find>initDotNet</find>
+      <find>load</find>
+      <find>getVers</find>
+      <find>getProperty</find>
+      <find>getVe</find>
+      <find>Load</find>
+      <find>init</find>
+    </findStrings>
+    <replaceStrings>
+      <replace>0.2.5.0</replace>
+    </replaceStrings>
+    <dirStrings>
+      <dir>C:\Users\Nebil\Desktop\projects\jni4net</dir>
+    </dirStrings>
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="GradleLocalSettings">
+    <option name="externalProjectsViewState">
+      <projects_view />
+    </option>
+  </component>
+  <component name="IdeDocumentHistory">
+    <option name="CHANGED_PATHS">
+      <list>
+        <option value="$PROJECT_DIR$/tools/keys/gennetkey.cmd" />
+        <option value="$PROJECT_DIR$/tools/loadTools.cmd" />
+        <option value="$PROJECT_DIR$/jni4net.j/src/main/java/java_/lang/reflect/TypeVariable_.java" />
+        <option value="$PROJECT_DIR$/jni4net.j/src/main/java/java_/lang/reflect/GenericDeclaration_.java" />
+        <option value="$PROJECT_DIR$/jni4net.n.w32.v40/pom.xml" />
+        <option value="$PROJECT_DIR$/jni4net.n.w64.v20/pom.xml" />
+        <option value="$PROJECT_DIR$/jni4net.n.w64.v40/pom.xml" />
+        <option value="$PROJECT_DIR$/jni4net.n.w64.v40/src/jni4net.n.w64.v40.csproj" />
+        <option value="$PROJECT_DIR$/jni4net.n.w64.v20/src/jni4net.n.w64.v20.csproj" />
+        <option value="$PROJECT_DIR$/jni4net.n.w32.v40/src/jni4net.n.w32.v40.csproj" />
+        <option value="$PROJECT_DIR$/jni4net.n.w32.v20/src/jni4net.n.w32.v20.csproj" />
+        <option value="$PROJECT_DIR$/jni4net.n.w32.v20/pom.xml" />
+        <option value="$PROJECT_DIR$/jni4net.j/pom.xml" />
+        <option value="$PROJECT_DIR$/pom.xml" />
+        <option value="$PROJECT_DIR$/jni4net.test.n/pom.xml" />
+        <option value="$PROJECT_DIR$/jni4net.j/src/main/java/net/sf/jni4net/Bridge.java" />
+        <option value="$PROJECT_DIR$/jni4net.j/src/main/filtered-resources/META-INF/jni4net.properties" />
+        <option value="$PROJECT_DIR$/jni4net.test.j/src/test/java/net/sf/jni4net/test/TestClr.java" />
+        <option value="$PROJECT_DIR$/jni4net.j/src/main/java/net/sf/jni4net/CLRLoader.java" />
+      </list>
+    </option>
+  </component>
+  <component name="MavenProjectNavigator">
+    <treeState>
+      <expand />
+      <select />
+    </treeState>
+  </component>
+  <component name="ProjectFrameBounds" extendedState="7">
+    <option name="x" value="260" />
+    <option name="y" value="20" />
+    <option name="width" value="1400" />
+    <option name="height" value="1000" />
+  </component>
+  <component name="ProjectLevelVcsManager" settingsEditedManually="true" />
+  <component name="ProjectView">
+    <navigator currentView="ProjectPane" proportions="" version="1">
+      <flattenPackages />
+      <showMembers />
+      <showModules />
+      <showLibraryContents />
+      <hideEmptyPackages />
+      <abbreviatePackageNames />
+      <autoscrollToSource />
+      <autoscrollFromSource />
+      <sortByType />
+      <manualOrder />
+      <foldersAlwaysOnTop value="true" />
+    </navigator>
+    <panes>
+      <pane id="AndroidView" />
+      <pane id="Scope" />
+      <pane id="ProjectPane">
+        <subPane>
+          <expand>
+            <path>
+              <item name="jni4net" type="b2602c69:ProjectViewProjectNode" />
+              <item name="jni4net" type="462c0819:PsiDirectoryNode" />
+            </path>
+            <path>
+              <item name="jni4net" type="b2602c69:ProjectViewProjectNode" />
+              <item name="jni4net" type="462c0819:PsiDirectoryNode" />
+              <item name="jni4net.j" type="462c0819:PsiDirectoryNode" />
+            </path>
+            <path>
+              <item name="jni4net" type="b2602c69:ProjectViewProjectNode" />
+              <item name="jni4net" type="462c0819:PsiDirectoryNode" />
+              <item name="jni4net.j" type="462c0819:PsiDirectoryNode" />
+              <item name="src" type="462c0819:PsiDirectoryNode" />
+            </path>
+            <path>
+              <item name="jni4net" type="b2602c69:ProjectViewProjectNode" />
+              <item name="jni4net" type="462c0819:PsiDirectoryNode" />
+              <item name="jni4net.j" type="462c0819:PsiDirectoryNode" />
+              <item name="src" type="462c0819:PsiDirectoryNode" />
+              <item name="main" type="462c0819:PsiDirectoryNode" />
+            </path>
+            <path>
+              <item name="jni4net" type="b2602c69:ProjectViewProjectNode" />
+              <item name="jni4net" type="462c0819:PsiDirectoryNode" />
+              <item name="jni4net.j" type="462c0819:PsiDirectoryNode" />
+              <item name="src" type="462c0819:PsiDirectoryNode" />
+              <item name="main" type="462c0819:PsiDirectoryNode" />
+              <item name="filtered-resources" type="462c0819:PsiDirectoryNode" />
+            </path>
+            <path>
+              <item name="jni4net" type="b2602c69:ProjectViewProjectNode" />
+              <item name="jni4net" type="462c0819:PsiDirectoryNode" />
+              <item name="jni4net.j" type="462c0819:PsiDirectoryNode" />
+              <item name="src" type="462c0819:PsiDirectoryNode" />
+              <item name="main" type="462c0819:PsiDirectoryNode" />
+              <item name="filtered-resources" type="462c0819:PsiDirectoryNode" />
+              <item name="META-INF" type="462c0819:PsiDirectoryNode" />
+            </path>
+            <path>
+              <item name="jni4net" type="b2602c69:ProjectViewProjectNode" />
+              <item name="jni4net" type="462c0819:PsiDirectoryNode" />
+              <item name="jni4net.j" type="462c0819:PsiDirectoryNode" />
+              <item name="src" type="462c0819:PsiDirectoryNode" />
+              <item name="main" type="462c0819:PsiDirectoryNode" />
+              <item name="java" type="462c0819:PsiDirectoryNode" />
+            </path>
+            <path>
+              <item name="jni4net" type="b2602c69:ProjectViewProjectNode" />
+              <item name="jni4net" type="462c0819:PsiDirectoryNode" />
+              <item name="jni4net.j" type="462c0819:PsiDirectoryNode" />
+              <item name="src" type="462c0819:PsiDirectoryNode" />
+              <item name="main" type="462c0819:PsiDirectoryNode" />
+              <item name="java" type="462c0819:PsiDirectoryNode" />
+              <item name="jni4net" type="462c0819:PsiDirectoryNode" />
+            </path>
+            <path>
+              <item name="jni4net" type="b2602c69:ProjectViewProjectNode" />
+              <item name="jni4net" type="462c0819:PsiDirectoryNode" />
+              <item name="jni4net.tested.n" type="462c0819:PsiDirectoryNode" />
+            </path>
+            <path>
+              <item name="jni4net" type="b2602c69:ProjectViewProjectNode" />
+              <item name="jni4net" type="462c0819:PsiDirectoryNode" />
+              <item name="jni4net.tested.n" type="462c0819:PsiDirectoryNode" />
+              <item name="target" type="462c0819:PsiDirectoryNode" />
+            </path>
+          </expand>
+          <select />
+        </subPane>
+      </pane>
+      <pane id="PackagesPane" />
+      <pane id="Scratches" />
+    </panes>
+  </component>
+  <component name="RunDashboard">
+    <option name="ruleStates">
+      <list>
+        <RuleState>
+          <option name="name" value="ConfigurationTypeDashboardGroupingRule" />
+        </RuleState>
+        <RuleState>
+          <option name="name" value="StatusDashboardGroupingRule" />
+        </RuleState>
+      </list>
+    </option>
+  </component>
+  <component name="RunManager" selected="JUnit.TestClr">
+    <configuration name="TestClr" type="JUnit" factoryName="JUnit" temporary="true" nameIsGenerated="true">
+      <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea">
+        <pattern>
+          <option name="PATTERN" value="net.sf.jni4net.test.*" />
+          <option name="ENABLED" value="true" />
+        </pattern>
+      </extension>
+      <module name="jni4net.test.j" />
+      <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+      <option name="ALTERNATIVE_JRE_PATH" />
+      <option name="PACKAGE_NAME" value="net.sf.jni4net.test" />
+      <option name="MAIN_CLASS_NAME" value="net.sf.jni4net.test.TestClr" />
+      <option name="METHOD_NAME" />
+      <option name="TEST_OBJECT" value="class" />
+      <option name="VM_PARAMETERS" value="-ea" />
+      <option name="PARAMETERS" />
+      <option name="WORKING_DIRECTORY" value="$MODULE_DIR$" />
+      <option name="ENV_VARIABLES" />
+      <option name="PASS_PARENT_ENVS" value="true" />
+      <option name="TEST_SEARCH_SCOPE">
+        <value defaultName="singleModule" />
+      </option>
+      <envs />
+      <patterns />
+    </configuration>
+    <configuration default="true" type="Applet" factoryName="Applet">
+      <option name="HTML_USED" value="false" />
+      <option name="WIDTH" value="400" />
+      <option name="HEIGHT" value="300" />
+      <option name="POLICY_FILE" value="$APPLICATION_HOME_DIR$/bin/appletviewer.policy" />
+      <module />
+    </configuration>
+    <configuration default="true" type="Application" factoryName="Application">
+      <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea" />
+      <option name="MAIN_CLASS_NAME" />
+      <option name="VM_PARAMETERS" />
+      <option name="PROGRAM_PARAMETERS" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+      <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+      <option name="ALTERNATIVE_JRE_PATH" />
+      <option name="ENABLE_SWING_INSPECTOR" value="false" />
+      <option name="ENV_VARIABLES" />
+      <option name="PASS_PARENT_ENVS" value="true" />
+      <module name="" />
+      <envs />
+    </configuration>
+    <configuration default="true" type="JUnit" factoryName="JUnit">
+      <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea" />
+      <module name="" />
+      <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+      <option name="ALTERNATIVE_JRE_PATH" />
+      <option name="PACKAGE_NAME" />
+      <option name="MAIN_CLASS_NAME" />
+      <option name="METHOD_NAME" />
+      <option name="TEST_OBJECT" value="class" />
+      <option name="VM_PARAMETERS" value="-ea" />
+      <option name="PARAMETERS" />
+      <option name="WORKING_DIRECTORY" value="$MODULE_DIR$" />
+      <option name="ENV_VARIABLES" />
+      <option name="PASS_PARENT_ENVS" value="true" />
+      <option name="TEST_SEARCH_SCOPE">
+        <value defaultName="singleModule" />
+      </option>
+      <envs />
+      <patterns />
+    </configuration>
+    <configuration default="true" type="#org.jetbrains.idea.devkit.run.PluginConfigurationType" factoryName="Plugin">
+      <module name="" />
+      <option name="VM_PARAMETERS" value="-Xmx512m -Xms256m -XX:MaxPermSize=250m -ea" />
+      <option name="PROGRAM_PARAMETERS" />
+      <predefined_log_file id="idea.log" enabled="true" />
+    </configuration>
+    <configuration default="true" type="Remote" factoryName="Remote">
+      <option name="USE_SOCKET_TRANSPORT" value="true" />
+      <option name="SERVER_MODE" value="false" />
+      <option name="SHMEM_ADDRESS" value="javadebug" />
+      <option name="HOST" value="localhost" />
+      <option name="PORT" value="5005" />
+    </configuration>
+    <configuration default="true" type="TestNG" factoryName="TestNG">
+      <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea" />
+      <module name="" />
+      <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+      <option name="ALTERNATIVE_JRE_PATH" />
+      <option name="SUITE_NAME" />
+      <option name="PACKAGE_NAME" />
+      <option name="MAIN_CLASS_NAME" />
+      <option name="METHOD_NAME" />
+      <option name="GROUP_NAME" />
+      <option name="TEST_OBJECT" value="CLASS" />
+      <option name="VM_PARAMETERS" value="-ea" />
+      <option name="PARAMETERS" />
+      <option name="WORKING_DIRECTORY" value="$MODULE_DIR$" />
+      <option name="OUTPUT_DIRECTORY" />
+      <option name="ANNOTATION_TYPE" />
+      <option name="ENV_VARIABLES" />
+      <option name="PASS_PARENT_ENVS" value="true" />
+      <option name="TEST_SEARCH_SCOPE">
+        <value defaultName="singleModule" />
+      </option>
+      <option name="USE_DEFAULT_REPORTERS" value="false" />
+      <option name="PROPERTIES_FILE" />
+      <envs />
+      <properties />
+      <listeners />
+    </configuration>
+    <recent_temporary>
+      <list size="1">
+        <item index="0" class="java.lang.String" itemvalue="JUnit.TestClr" />
+      </list>
+    </recent_temporary>
+  </component>
+  <component name="ShelveChangesManager" show_recycled="false">
+    <option name="remove_strategy" value="false" />
+  </component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="0bd9512f-5149-48e4-a3c5-0950e25b623b" name="Default" comment="" />
+      <created>1506936435014</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1506936435014</updated>
+    </task>
+    <servers />
+  </component>
+  <component name="TestHistory">
+    <history-entry file="TestClr - 2017.10.02 at 16h 45m 08s.xml">
+      <configuration name="TestClr" configurationId="JUnit" />
+    </history-entry>
+    <history-entry file="TestClr - 2017.10.02 at 16h 57m 32s.xml">
+      <configuration name="TestClr" configurationId="JUnit" />
+    </history-entry>
+    <history-entry file="TestClr - 2017.10.02 at 17h 04m 31s.xml">
+      <configuration name="TestClr" configurationId="JUnit" />
+    </history-entry>
+    <history-entry file="TestClr - 2017.10.02 at 17h 06m 22s.xml">
+      <configuration name="TestClr" configurationId="JUnit" />
+    </history-entry>
+    <history-entry file="TestClr - 2017.10.02 at 17h 28m 38s.xml">
+      <configuration name="TestClr" configurationId="JUnit" />
+    </history-entry>
+    <history-entry file="TestClr - 2017.10.02 at 17h 42m 20s.xml">
+      <configuration name="TestClr" configurationId="JUnit" />
+    </history-entry>
+  </component>
+  <component name="ToolWindowManager">
+    <frame x="-8" y="-8" width="1936" height="1056" extended-state="7" />
+    <editor active="true" />
+    <layout>
+      <window_info id="Palette" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="4" side_tool="false" content_ui="tabs" />
+      <window_info id="TODO" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="9" side_tool="false" content_ui="tabs" />
+      <window_info id="Messages" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.32936078" sideWeight="0.5" order="-1" side_tool="false" content_ui="tabs" />
+      <window_info id="Palette&#9;" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="0" side_tool="false" content_ui="tabs" />
+      <window_info id="Image Layers" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="6" side_tool="false" content_ui="tabs" />
+      <window_info id="Capture Analysis" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
+      <window_info id="Event Log" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="0" side_tool="true" content_ui="tabs" />
+      <window_info id="Maven Projects" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.23560767" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
+      <window_info id="Run" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.32936078" sideWeight="0.5" order="5" side_tool="false" content_ui="tabs" />
+      <window_info id="Version Control" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
+      <window_info id="Terminal" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.30877572" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
+      <window_info id="Capture Tool" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="0" side_tool="false" content_ui="tabs" />
+      <window_info id="Designer" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
+      <window_info id="Project" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.18123667" sideWeight="0.5" order="4" side_tool="false" content_ui="combo" />
+      <window_info id="Structure" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="5" side_tool="false" content_ui="tabs" />
+      <window_info id="Ant Build" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="6" side_tool="false" content_ui="tabs" />
+      <window_info id="UI Designer" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
+      <window_info id="Theme Preview" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
+      <window_info id="Debug" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.4" sideWeight="0.5" order="6" side_tool="false" content_ui="tabs" />
+      <window_info id="Favorites" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="3" side_tool="true" content_ui="tabs" />
+      <window_info id="Cvs" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="7" side_tool="false" content_ui="tabs" />
+      <window_info id="Message" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
+      <window_info id="Commander" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.4" sideWeight="0.5" order="5" side_tool="false" content_ui="tabs" />
+      <window_info id="Hierarchy" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="7" side_tool="false" content_ui="combo" />
+      <window_info id="Inspection" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.4" sideWeight="0.5" order="8" side_tool="false" content_ui="tabs" />
+      <window_info id="Find" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="4" side_tool="false" content_ui="tabs" />
+    </layout>
+  </component>
+  <component name="VcsContentAnnotationSettings">
+    <option name="myLimit" value="2678400000" />
+  </component>
+  <component name="XDebuggerManager">
+    <breakpoint-manager />
+    <watches-manager />
+  </component>
+  <component name="editorHistoryManager">
+    <entry file="file://$PROJECT_DIR$/pom.xml">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="425">
+          <caret line="25" column="14" lean-forward="false" selection-start-line="25" selection-start-column="14" selection-end-line="25" selection-end-column="14" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/jni4net.j/pom.xml">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="323">
+          <caret line="19" column="21" lean-forward="false" selection-start-line="19" selection-start-column="21" selection-end-line="19" selection-end-column="21" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/jni4net.j/src/main/java/net/sf/jni4net/CLRLoader.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="884">
+          <caret line="52" column="5" lean-forward="true" selection-start-line="52" selection-start-column="5" selection-end-line="52" selection-end-column="5" />
+          <folding>
+            <element signature="imports" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/tools/keys/gennetkey.cmd">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="0">
+          <caret line="0" column="23" lean-forward="false" selection-start-line="0" selection-start-column="23" selection-end-line="0" selection-end-column="23" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/jni4net.j/src/main/java/java_/lang/reflect/Type_.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="340">
+          <caret line="29" column="6" lean-forward="false" selection-start-line="29" selection-start-column="6" selection-end-line="29" selection-end-column="6" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/jni4net.j/src/main/java/java_/lang/reflect/TypeVariable_.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="-4">
+          <caret line="12" column="26" lean-forward="false" selection-start-line="12" selection-start-column="26" selection-end-line="12" selection-end-column="26" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/jni4net.n.w32.v40/src/jni4net.n.w32.v40.csproj">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="843">
+          <caret line="103" column="70" lean-forward="false" selection-start-line="103" selection-start-column="70" selection-end-line="103" selection-end-column="70" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/jni4net.n.w32.v20/src/jni4net.n.w32.v20.csproj">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="322">
+          <caret line="103" column="70" lean-forward="false" selection-start-line="103" selection-start-column="63" selection-end-line="103" selection-end-column="70" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/jni4net.n.w64.v20/src/jni4net.n.w64.v20.csproj">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="1700">
+          <caret line="103" column="70" lean-forward="false" selection-start-line="103" selection-start-column="70" selection-end-line="103" selection-end-column="70" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/jni4net.n.w64.v40/src/jni4net.n.w64.v40.csproj">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="1700">
+          <caret line="103" column="70" lean-forward="false" selection-start-line="103" selection-start-column="70" selection-end-line="103" selection-end-column="70" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/jni4net.j/src/main/java/java_/lang/reflect/GenericDeclaration_.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="340">
+          <caret line="29" column="9" lean-forward="false" selection-start-line="29" selection-start-column="9" selection-end-line="29" selection-end-column="9" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/jni4net.n.w32.v40/pom.xml">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="172">
+          <caret line="83" column="80" lean-forward="false" selection-start-line="83" selection-start-column="80" selection-end-line="83" selection-end-column="80" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/jni4net.n.w64.v20/pom.xml">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="1209">
+          <caret line="84" column="80" lean-forward="false" selection-start-line="84" selection-start-column="80" selection-end-line="84" selection-end-column="80" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/jni4net.n.w64.v40/pom.xml">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="1360">
+          <caret line="83" column="80" lean-forward="false" selection-start-line="83" selection-start-column="80" selection-end-line="83" selection-end-column="80" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/tools/loadTools.cmd">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="119">
+          <caret line="7" column="0" lean-forward="true" selection-start-line="7" selection-start-column="0" selection-end-line="7" selection-end-column="0" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/jni4net.test.n/pom.xml">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="343">
+          <caret line="92" column="79" lean-forward="false" selection-start-line="92" selection-start-column="79" selection-end-line="92" selection-end-column="79" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/jni4net.n.w32.v20/pom.xml">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="459">
+          <caret line="27" column="20" lean-forward="true" selection-start-line="27" selection-start-column="20" selection-end-line="27" selection-end-column="20" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/jni4net.test.j/pom.xml">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="290">
+          <caret line="19" column="20" lean-forward="false" selection-start-line="19" selection-start-column="20" selection-end-line="19" selection-end-column="20" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/jni4net.j/pom.xml">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="323">
+          <caret line="19" column="21" lean-forward="false" selection-start-line="19" selection-start-column="21" selection-end-line="19" selection-end-column="21" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/pom.xml">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="272">
+          <caret line="25" column="14" lean-forward="false" selection-start-line="25" selection-start-column="14" selection-end-line="25" selection-end-column="14" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/jni4net.test.j/src/test/java/net/sf/jni4net/test/TestClr.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="170">
+          <caret line="44" column="8" lean-forward="false" selection-start-line="44" selection-start-column="8" selection-end-line="44" selection-end-column="8" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/jni4net.tested.n/pom.xml">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="119">
+          <caret line="7" column="13" lean-forward="true" selection-start-line="7" selection-start-column="13" selection-end-line="7" selection-end-column="13" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/jni4net.j/src/main/filtered-resources/META-INF/jni4net.properties">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="0">
+          <caret line="0" column="30" lean-forward="false" selection-start-line="0" selection-start-column="17" selection-end-line="0" selection-end-column="35" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/jni4net.j/src/main/java/net/sf/jni4net/Bridge.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="231">
+          <caret line="32" column="0" lean-forward="true" selection-start-line="32" selection-start-column="0" selection-end-line="32" selection-end-column="0" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/jni4net.j/src/main/java/net/sf/jni4net/CLRLoader.java">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="374">
+          <caret line="45" column="36" lean-forward="true" selection-start-line="45" selection-start-column="36" selection-end-line="45" selection-end-column="36" />
+          <folding>
+            <element signature="imports" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+  </component>
+  <component name="masterDetails">
+    <states>
+      <state key="ProjectJDKs.UI">
+        <settings>
+          <last-edited>1.8</last-edited>
+          <splitter-proportions>
+            <option name="proportions">
+              <list>
+                <option value="0.2" />
+              </list>
+            </option>
+          </splitter-proportions>
+        </settings>
+      </state>
+    </states>
+  </component>
+</project>

--- a/jni4net.iml
+++ b/jni4net.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module MavenProjectsManager.isMavenModule="true" org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" relativePaths="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5" inherit-compiler-output="false">
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
@@ -10,4 +10,3 @@
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>
-

--- a/jni4net.j/jni4net.j.iml
+++ b/jni4net.j/jni4net.j.iml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module MavenProjectsManager.isMavenModule="true" org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" relativePaths="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5" inherit-compiler-output="false">
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/filtered-resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/main/filtered-resources" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Maven: log4j:log4j:1.2.17" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.5" level="project" />
   </component>
 </module>
-

--- a/jni4net.j/pom.xml
+++ b/jni4net.j/pom.xml
@@ -12,6 +12,12 @@
     <version>0.8.8.0</version>
     <name>jni4net Java</name>
     <dependencies>
+        <!-- https://mvnrepository.com/artifact/log4j/log4j -->
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/jni4net.j/src/main/java/java_/lang/reflect/GenericDeclaration_.java
+++ b/jni4net.j/src/main/java/java_/lang/reflect/GenericDeclaration_.java
@@ -27,7 +27,7 @@ public final class GenericDeclaration_ {
 
 //<generated-proxy>
 @net.sf.jni4net.attributes.ClrProxy
-class __GenericDeclaration extends system.Object implements java.lang.reflect.GenericDeclaration {
+abstract class __GenericDeclaration extends system.Object implements java.lang.reflect.GenericDeclaration {
     
     protected __GenericDeclaration(net.sf.jni4net.inj.INJEnv __env, long __handle) {
             super(__env, __handle);

--- a/jni4net.j/src/main/java/java_/lang/reflect/TypeVariable_.java
+++ b/jni4net.j/src/main/java/java_/lang/reflect/TypeVariable_.java
@@ -27,7 +27,7 @@ public final class TypeVariable_ {
 
 //<generated-proxy>
 @net.sf.jni4net.attributes.ClrProxy
-class __TypeVariable extends system.Object implements java.lang.reflect.TypeVariable {
+abstract class __TypeVariable extends system.Object implements java.lang.reflect.TypeVariable {
     
     protected __TypeVariable(net.sf.jni4net.inj.INJEnv __env, long __handle) {
             super(__env, __handle);

--- a/jni4net.j/src/main/java/net/sf/jni4net/CLRLoader.java
+++ b/jni4net.j/src/main/java/net/sf/jni4net/CLRLoader.java
@@ -7,8 +7,6 @@ This content is released under the (http://opensource.org/licenses/MIT) MIT Lice
 
 package net.sf.jni4net;
 
-import system.NotSupportedException;
-
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
@@ -16,6 +14,7 @@ import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Properties;
+import org.apache.log4j.Logger;
 
 /**
  * @author Pavel Savara (original)
@@ -23,6 +22,8 @@ import java.util.Properties;
 class CLRLoader {
 	private static String version;
     private static String platform;
+
+	private static Logger logger = Logger.getLogger(CLRLoader.class);
 
     public static void 	init(File fileOrDirectory) throws IOException {
 		if (!Bridge.isRegistered) {
@@ -36,13 +37,16 @@ class CLRLoader {
                 System.load(file);
 				final int res = Bridge.initDotNet();
 				if (res != 0) {
-					System.err.println("Can't initialize jni4net Bridge from " + file);
-					throw new net.sf.jni4net.inj.INJException("Can't initialize jni4net Bridge. Code:"+res);
+					//System.err.println("Can't initialize jni4net Bridge from " + file);
+					//throw new net.sf.jni4net.inj.INJException("Can't initialize jni4net Bridge. Code:"+res);
+					logger.error("Can't initialize jni4net Bridge from " + file);
+					logger.error("Can't initialize jni4net Bridge. Code: "+ res);
 				}
 				Bridge.isRegistered = true;
 			} catch (Throwable th) {
-				System.err.println("Can't initialize jni4net Bridge" + th.getMessage());
-				throw new net.sf.jni4net.inj.INJException("Can't initialize jni4net Bridge", th);
+				//System.err.println("Can't initialize jni4net Bridge" + th.getMessage());
+				//throw new net.sf.jni4net.inj.INJException("Can't initialize jni4net Bridge", th);
+				logger.error("Can't initialize jni4net Bridge: " + th.getMessage());
 			}
 		}
 	}

--- a/jni4net.n.w32.v20/jni4net.n.w32.v20.iml
+++ b/jni4net.n.w32.v20/jni4net.n.w32.v20.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
@@ -11,4 +11,3 @@
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>
-

--- a/jni4net.n.w32.v20/pom.xml
+++ b/jni4net.n.w32.v20/pom.xml
@@ -21,14 +21,14 @@
         <dependency>
             <groupId>net.sf.jni4net</groupId>
             <artifactId>selvin.exportdllattribute</artifactId>
-            <version>0.2.6.0</version>
+            <version>0.2.5.0</version>
             <type>dotnet:library</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.sf.jni4net</groupId>
             <artifactId>selvin.exportdll</artifactId>
-            <version>0.2.6.0</version>
+            <version>0.2.5.0</version>
             <type>dotnet:library</type>
             <scope>provided</scope>
         </dependency>
@@ -71,18 +71,18 @@
                         <configuration>
                             <tasks>
                                 <resolveArtifact property="exportdll" groupId="net.sf.jni4net"
-                                                 artifactId="selvin.exportdll" version="0.2.6.0"
+                                                 artifactId="selvin.exportdll" version="0.2.5.0"
                                                  type="dotnet:library"/>
                                 <resolveArtifact property="exportdllattribute" groupId="net.sf.jni4net"
-                                                 artifactId="selvin.exportdllattribute" version="0.2.6.0"
+                                                 artifactId="selvin.exportdllattribute" version="0.2.5.0"
                                                  type="dotnet:library"/>
-                                <copy file="${exportdll}" tofile="target/tool/selvin.exportdll-0.2.6.0.exe"/>
+                                <copy file="${exportdll}" tofile="target/tool/selvin.exportdll-0.2.5.0.exe"/>
                                 <copy file="${exportdllattribute}" todir="target/tool"/>
                                 <exec executable="cmd.exe" failonerror="false" dir="target">
-                                    <arg value="/c tool\selvin.exportdll-0.2.6.0.exe jni4net.n.w32.v20-${jni4net.version}.dll &quot;%ProgramFiles(x86)%\Microsoft SDKs\Windows\v8.0A\Bin\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v2.0.50727\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x32"/>
+                                    <arg value="/c tool\selvin.exportdll-0.2.5.0.exe jni4net.n.w32.v20-${jni4net.version}.dll &quot;%ProgramFiles(x86)%\Microsoft SDKs\Windows\v8.0A\Bin\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v2.0.50727\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x32"/>
                                 </exec>
                                 <exec executable="cmd.exe" failonerror="false" dir="target">
-                                    <arg value="/c tool\selvin.exportdll-0.2.6.0.exe jni4net.n.w32.v20-${jni4net.version}.dll &quot;%ProgramFiles%\Microsoft SDKs\Windows\v8.0A\Bin\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v2.0.50727\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x32"/>
+                                    <arg value="/c tool\selvin.exportdll-0.2.5.0.exe jni4net.n.w32.v20-${jni4net.version}.dll &quot;%ProgramFiles%\Microsoft SDKs\Windows\v8.0A\Bin\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v2.0.50727\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x32"/>
                                 </exec>
                             </tasks>
                         </configuration>

--- a/jni4net.n.w32.v20/src/jni4net.n.w32.v20.csproj
+++ b/jni4net.n.w32.v20/src/jni4net.n.w32.v20.csproj
@@ -60,9 +60,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="selvin.exportdllattribute-0.2.6.0, Version=0.0.0.0, Culture=neutral, PublicKeyToken=57baad0f7b3885b0, processorArchitecture=MSIL">
+    <Reference Include="selvin.exportdllattribute-0.2.5.0, Version=0.0.0.0, Culture=neutral, PublicKeyToken=57baad0f7b3885b0, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\tools\lib\selvin.exportdllattribute-0.2.6.0.dll</HintPath>
+      <HintPath>..\..\tools\lib\selvin.exportdllattribute-0.2.5.0.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -101,7 +101,7 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent>"$(SolutionDir)\tools\lib\selvin.exportdll-0.2.6.0.exe" "$(TargetPath)" "%25ProgramFiles%25\Microsoft SDKs\Windows\v7.0A\Bin\ildasm.exe" "%25windir%25\Microsoft.NET\Framework\v2.0.50727\ilasm.exe" "$(SolutionDir)/tools/keys/jni4net.snk" "$(SolutionDir)/tools/keys/jni4net.snk" /Debug /x32</PostBuildEvent>
+    <PostBuildEvent>"$(SolutionDir)\tools\lib\selvin.exportdll-0.2.5.0.exe" "$(TargetPath)" "%25ProgramFiles%25\Microsoft SDKs\Windows\v7.0A\Bin\ildasm.exe" "%25windir%25\Microsoft.NET\Framework\v2.0.50727\ilasm.exe" "$(SolutionDir)/tools/keys/jni4net.snk" "$(SolutionDir)/tools/keys/jni4net.snk" /Debug /x32</PostBuildEvent>
     <PreBuildEvent>if not exist $(OutDir)\build-sources\generated-sources\META-INF mkdir $(OutDir)\build-sources\generated-sources\META-INF\
 echo [assembly: System.Reflection.AssemblyVersion("0.8.8.0")] &gt; $(OutDir)\build-sources\generated-sources\META-INF\AssemblyInfo.cs
 if not exist $(SolutionDir)\tools\keys\jni4net.snk "%25ProgramFiles%25\Microsoft SDKs\Windows\v7.0A\bin\sn.exe" -k $(SolutionDir)\tools\keys\jni4net.snk

--- a/jni4net.n.w32.v40/jni4net.n.w32.v40.iml
+++ b/jni4net.n.w32.v40/jni4net.n.w32.v40.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
@@ -11,4 +11,3 @@
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>
-

--- a/jni4net.n.w32.v40/pom.xml
+++ b/jni4net.n.w32.v40/pom.xml
@@ -21,14 +21,14 @@
         <dependency>
             <groupId>net.sf.jni4net</groupId>
             <artifactId>selvin.exportdllattribute</artifactId>
-            <version>0.2.6.0</version>
+            <version>0.2.5.0</version>
             <type>dotnet:library</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.sf.jni4net</groupId>
             <artifactId>selvin.exportdll</artifactId>
-            <version>0.2.6.0</version>
+            <version>0.2.5.0</version>
             <type>dotnet:library</type>
             <scope>provided</scope>
         </dependency>
@@ -70,18 +70,18 @@
                         <configuration>
                             <tasks>
                                 <resolveArtifact property="exportdll" groupId="net.sf.jni4net"
-                                                 artifactId="selvin.exportdll" version="0.2.6.0"
+                                                 artifactId="selvin.exportdll" version="0.2.5.0"
                                                  type="dotnet:library"/>
                                 <resolveArtifact property="exportdllattribute" groupId="net.sf.jni4net"
-                                                 artifactId="selvin.exportdllattribute" version="0.2.6.0"
+                                                 artifactId="selvin.exportdllattribute" version="0.2.5.0"
                                                  type="dotnet:library"/>
-                                <copy file="${exportdll}" tofile="target/tool/selvin.exportdll-0.2.6.0.exe"/>
+                                <copy file="${exportdll}" tofile="target/tool/selvin.exportdll-0.2.5.0.exe"/>
                                 <copy file="${exportdllattribute}" todir="target/tool"/>
                                 <exec executable="cmd.exe" failonerror="false" dir="target">
-                                    <arg value="/c tool\selvin.exportdll-0.2.6.0.exe jni4net.n.w32.v40-${jni4net.version}.dll &quot;%ProgramFiles(x86)%\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x32"/>
+                                    <arg value="/c tool\selvin.exportdll-0.2.5.0.exe jni4net.n.w32.v40-${jni4net.version}.dll &quot;%ProgramFiles(x86)%\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x32"/>
                                 </exec>
                                 <exec executable="cmd.exe" failonerror="false" dir="target">
-                                    <arg value="/c tool\selvin.exportdll-0.2.6.0.exe jni4net.n.w32.v40-${jni4net.version}.dll &quot;%ProgramFiles%\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x32"/>
+                                    <arg value="/c tool\selvin.exportdll-0.2.5.0.exe jni4net.n.w32.v40-${jni4net.version}.dll &quot;%ProgramFiles%\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x32"/>
                                 </exec>
                             </tasks>
                         </configuration>

--- a/jni4net.n.w32.v40/src/jni4net.n.w32.v40.csproj
+++ b/jni4net.n.w32.v40/src/jni4net.n.w32.v40.csproj
@@ -60,9 +60,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="selvin.exportdllattribute-0.2.6.0, Version=0.0.0.0, Culture=neutral, PublicKeyToken=57baad0f7b3885b0, processorArchitecture=MSIL">
+    <Reference Include="selvin.exportdllattribute-0.2.5.0, Version=0.0.0.0, Culture=neutral, PublicKeyToken=57baad0f7b3885b0, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\tools\lib\selvin.exportdllattribute-0.2.6.0.dll</HintPath>
+      <HintPath>..\..\tools\lib\selvin.exportdllattribute-0.2.5.0.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -101,7 +101,7 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent>"$(SolutionDir)\tools\lib\selvin.exportdll-0.2.6.0.exe" "$(TargetPath)" "%25ProgramFiles%25\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\ildasm.exe" "%25windir%25\Microsoft.NET\Framework\v4.0.30319\ilasm.exe" "$(SolutionDir)/tools/keys/jni4net.snk" "$(SolutionDir)/tools/keys/jni4net.snk" /Debug /x32</PostBuildEvent>
+    <PostBuildEvent>"$(SolutionDir)\tools\lib\selvin.exportdll-0.2.5.0.exe" "$(TargetPath)" "%25ProgramFiles%25\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\ildasm.exe" "%25windir%25\Microsoft.NET\Framework\v4.0.30319\ilasm.exe" "$(SolutionDir)/tools/keys/jni4net.snk" "$(SolutionDir)/tools/keys/jni4net.snk" /Debug /x32</PostBuildEvent>
     <PreBuildEvent>if not exist $(OutDir)\build-sources\generated-sources\META-INF mkdir $(OutDir)\build-sources\generated-sources\META-INF\
 echo [assembly: System.Reflection.AssemblyVersion("0.8.8.0")] &gt; $(OutDir)\build-sources\generated-sources\META-INF\AssemblyInfo.cs
 if not exist $(SolutionDir)\tools\keys\jni4net.snk "%25ProgramFiles%25\Microsoft SDKs\Windows\v7.0A\bin\sn.exe" -k $(SolutionDir)\tools\keys\jni4net.snk

--- a/jni4net.n.w64.v20/jni4net.n.w64.v20.iml
+++ b/jni4net.n.w64.v20/jni4net.n.w64.v20.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
@@ -11,4 +11,3 @@
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>
-

--- a/jni4net.n.w64.v20/pom.xml
+++ b/jni4net.n.w64.v20/pom.xml
@@ -21,14 +21,14 @@
         <dependency>
             <groupId>net.sf.jni4net</groupId>
             <artifactId>selvin.exportdllattribute</artifactId>
-            <version>0.2.6.0</version>
+            <version>0.2.5.0</version>
             <type>dotnet:library</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.sf.jni4net</groupId>
             <artifactId>selvin.exportdll</artifactId>
-            <version>0.2.6.0</version>
+            <version>0.2.5.0</version>
             <type>dotnet:library</type>
             <scope>provided</scope>
         </dependency>
@@ -71,18 +71,18 @@
                         <configuration>
                             <tasks>
                                 <resolveArtifact property="exportdll" groupId="net.sf.jni4net"
-                                                 artifactId="selvin.exportdll" version="0.2.6.0"
+                                                 artifactId="selvin.exportdll" version="0.2.5.0"
                                                  type="dotnet:library"/>
                                 <resolveArtifact property="exportdllattribute" groupId="net.sf.jni4net"
-                                                 artifactId="selvin.exportdllattribute" version="0.2.6.0"
+                                                 artifactId="selvin.exportdllattribute" version="0.2.5.0"
                                                  type="dotnet:library"/>
-                                <copy file="${exportdll}" tofile="target/tool/selvin.exportdll-0.2.6.0.exe"/>
+                                <copy file="${exportdll}" tofile="target/tool/selvin.exportdll-0.2.5.0.exe"/>
                                 <copy file="${exportdllattribute}" todir="target/tool"/>
                                 <exec executable="cmd.exe" failonerror="false" dir="target">
-                                    <arg value="/c tool\selvin.exportdll-0.2.6.0.exe jni4net.n.w64.v20-${jni4net.version}.dll &quot;%ProgramFiles(x86)%\Microsoft SDKs\Windows\v8.0A\Bin\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v2.0.50727\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x64"/>
+                                    <arg value="/c tool\selvin.exportdll-0.2.5.0.exe jni4net.n.w64.v20-${jni4net.version}.dll &quot;%ProgramFiles(x86)%\Microsoft SDKs\Windows\v8.0A\Bin\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v2.0.50727\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x64"/>
                                 </exec>
                                 <exec executable="cmd.exe" failonerror="false" dir="target">
-                                    <arg value="/c tool\selvin.exportdll-0.2.6.0.exe jni4net.n.w64.v20-${jni4net.version}.dll &quot;%ProgramFiles%\Microsoft SDKs\Windows\v8.0A\Bin\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v2.0.50727\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x64"/>
+                                    <arg value="/c tool\selvin.exportdll-0.2.5.0.exe jni4net.n.w64.v20-${jni4net.version}.dll &quot;%ProgramFiles%\Microsoft SDKs\Windows\v8.0A\Bin\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v2.0.50727\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x64"/>
                                 </exec>
                             </tasks>
                         </configuration>

--- a/jni4net.n.w64.v20/src/jni4net.n.w64.v20.csproj
+++ b/jni4net.n.w64.v20/src/jni4net.n.w64.v20.csproj
@@ -60,9 +60,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="selvin.exportdllattribute-0.2.6.0, Version=0.0.0.0, Culture=neutral, PublicKeyToken=57baad0f7b3885b0, processorArchitecture=MSIL">
+    <Reference Include="selvin.exportdllattribute-0.2.5.0, Version=0.0.0.0, Culture=neutral, PublicKeyToken=57baad0f7b3885b0, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\tools\lib\selvin.exportdllattribute-0.2.6.0.dll</HintPath>
+      <HintPath>..\..\tools\lib\selvin.exportdllattribute-0.2.5.0.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -101,7 +101,7 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent>"$(SolutionDir)\tools\lib\selvin.exportdll-0.2.6.0.exe" "$(TargetPath)" "%25ProgramFiles%25\Microsoft SDKs\Windows\v7.0A\Bin\ildasm.exe" "%25windir%25\Microsoft.NET\Framework\v2.0.50727\ilasm.exe" "$(SolutionDir)/tools/keys/jni4net.snk" /Debug /x64</PostBuildEvent>
+    <PostBuildEvent>"$(SolutionDir)\tools\lib\selvin.exportdll-0.2.5.0.exe" "$(TargetPath)" "%25ProgramFiles%25\Microsoft SDKs\Windows\v7.0A\Bin\ildasm.exe" "%25windir%25\Microsoft.NET\Framework\v2.0.50727\ilasm.exe" "$(SolutionDir)/tools/keys/jni4net.snk" /Debug /x64</PostBuildEvent>
     <PreBuildEvent>if not exist $(OutDir)\build-sources\generated-sources\META-INF mkdir $(OutDir)\build-sources\generated-sources\META-INF\
 echo [assembly: System.Reflection.AssemblyVersion("0.8.8.0")] &gt; $(OutDir)\build-sources\generated-sources\META-INF\AssemblyInfo.cs
 if not exist $(SolutionDir)\tools\keys\jni4net.snk "%25ProgramFiles%25\Microsoft SDKs\Windows\v7.0A\bin\sn.exe" -k $(SolutionDir)\tools\keys\jni4net.snk

--- a/jni4net.n.w64.v40/jni4net.n.w64.v40.iml
+++ b/jni4net.n.w64.v40/jni4net.n.w64.v40.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
@@ -11,4 +11,3 @@
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>
-

--- a/jni4net.n.w64.v40/pom.xml
+++ b/jni4net.n.w64.v40/pom.xml
@@ -21,14 +21,14 @@
         <dependency>
             <groupId>net.sf.jni4net</groupId>
             <artifactId>selvin.exportdllattribute</artifactId>
-            <version>0.2.6.0</version>
+            <version>0.2.5.0</version>
             <type>dotnet:library</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.sf.jni4net</groupId>
             <artifactId>selvin.exportdll</artifactId>
-            <version>0.2.6.0</version>
+            <version>0.2.5.0</version>
             <type>dotnet:library</type>
             <scope>provided</scope>
         </dependency>
@@ -70,18 +70,18 @@
                         <configuration>
                             <tasks>
                                 <resolveArtifact property="exportdll" groupId="net.sf.jni4net"
-                                                 artifactId="selvin.exportdll" version="0.2.6.0"
+                                                 artifactId="selvin.exportdll" version="0.2.5.0"
                                                  type="dotnet:library"/>
                                 <resolveArtifact property="exportdllattribute" groupId="net.sf.jni4net"
-                                                 artifactId="selvin.exportdllattribute" version="0.2.6.0"
+                                                 artifactId="selvin.exportdllattribute" version="0.2.5.0"
                                                  type="dotnet:library"/>
-                                <copy file="${exportdll}" tofile="target/tool/selvin.exportdll-0.2.6.0.exe"/>
+                                <copy file="${exportdll}" tofile="target/tool/selvin.exportdll-0.2.5.0.exe"/>
                                 <copy file="${exportdllattribute}" todir="target/tool"/>
                                 <exec executable="cmd.exe" failonerror="false" dir="target">
-                                    <arg value="/c tool\selvin.exportdll-0.2.6.0.exe jni4net.n.w64.v40-${jni4net.version}.dll &quot;%ProgramFiles(x86)%\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x64"/>
+                                    <arg value="/c tool\selvin.exportdll-0.2.5.0.exe jni4net.n.w64.v40-${jni4net.version}.dll &quot;%ProgramFiles(x86)%\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x64"/>
                                 </exec>
                                 <exec executable="cmd.exe" failonerror="false" dir="target">
-                                    <arg value="/c tool\selvin.exportdll-0.2.6.0.exe jni4net.n.w64.v40-${jni4net.version}.dll &quot;%ProgramFiles%\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x64"/>
+                                    <arg value="/c tool\selvin.exportdll-0.2.5.0.exe jni4net.n.w64.v40-${jni4net.version}.dll &quot;%ProgramFiles%\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x64"/>
                                 </exec>
                             </tasks>
                         </configuration>

--- a/jni4net.n.w64.v40/src/jni4net.n.w64.v40.csproj
+++ b/jni4net.n.w64.v40/src/jni4net.n.w64.v40.csproj
@@ -60,9 +60,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="selvin.exportdllattribute-0.2.6.0, Version=0.0.0.0, Culture=neutral, PublicKeyToken=57baad0f7b3885b0, processorArchitecture=MSIL">
+    <Reference Include="selvin.exportdllattribute-0.2.5.0, Version=0.0.0.0, Culture=neutral, PublicKeyToken=57baad0f7b3885b0, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\tools\lib\selvin.exportdllattribute-0.2.6.0.dll</HintPath>
+      <HintPath>..\..\tools\lib\selvin.exportdllattribute-0.2.5.0.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -101,7 +101,7 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent>"$(SolutionDir)\tools\lib\selvin.exportdll-0.2.6.0.exe" "$(TargetPath)" "%25ProgramFiles%25\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\ildasm.exe" "%25windir%25\Microsoft.NET\Framework\v4.0.30319\ilasm.exe" "$(SolutionDir)/tools/keys/jni4net.snk" /Debug /x64</PostBuildEvent>
+    <PostBuildEvent>"$(SolutionDir)\tools\lib\selvin.exportdll-0.2.5.0.exe" "$(TargetPath)" "%25ProgramFiles%25\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\ildasm.exe" "%25windir%25\Microsoft.NET\Framework\v4.0.30319\ilasm.exe" "$(SolutionDir)/tools/keys/jni4net.snk" /Debug /x64</PostBuildEvent>
     <PreBuildEvent>if not exist $(OutDir)\build-sources\generated-sources\META-INF mkdir $(OutDir)\build-sources\generated-sources\META-INF\
 echo [assembly: System.Reflection.AssemblyVersion("0.8.8.0")] &gt; $(OutDir)\build-sources\generated-sources\META-INF\AssemblyInfo.cs
 if not exist $(SolutionDir)\tools\keys\jni4net.snk "%25ProgramFiles%25\Microsoft SDKs\Windows\v7.0A\bin\sn.exe" -k $(SolutionDir)\tools\keys\jni4net.snk

--- a/jni4net.n/jni4net.n.iml
+++ b/jni4net.n/jni4net.n.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module MavenProjectsManager.isMavenModule="true" org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" relativePaths="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5" inherit-compiler-output="false">
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
@@ -11,4 +11,3 @@
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>
-

--- a/jni4net.proxygen/jni4net.proxygen.iml
+++ b/jni4net.proxygen/jni4net.proxygen.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module MavenProjectsManager.isMavenModule="true" org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" relativePaths="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5" inherit-compiler-output="false">
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
@@ -10,6 +10,6 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="jni4net.j" />
+    <orderEntry type="library" name="Maven: log4j:log4j:1.2.17" level="project" />
   </component>
 </module>
-

--- a/jni4net.test.j/jni4net.test.j.iml
+++ b/jni4net.test.j/jni4net.test.j.iml
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module MavenProjectsManager.isMavenModule="true" org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" relativePaths="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5" inherit-compiler-output="false">
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="jni4net.j" />
+    <orderEntry type="library" name="Maven: log4j:log4j:1.2.17" level="project" />
     <orderEntry type="module" module-name="jni4net.tested.j" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.5" level="project" />
   </component>
 </module>
-

--- a/jni4net.test.n/jni4net.test.n.iml
+++ b/jni4net.test.n/jni4net.test.n.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module MavenProjectsManager.isMavenModule="true" org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" relativePaths="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5" inherit-compiler-output="false">
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
@@ -10,8 +10,8 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="jni4net.j" />
+    <orderEntry type="library" name="Maven: log4j:log4j:1.2.17" level="project" />
     <orderEntry type="module" module-name="jni4net.tested.j" />
     <orderEntry type="module" module-name="jni4net.test.j" />
   </component>
 </module>
-

--- a/jni4net.test.n/pom.xml
+++ b/jni4net.test.n/pom.xml
@@ -90,7 +90,7 @@
 				<artifactId>maven-dotnet-test-plugin</artifactId>
                 <version>0.17.jni4net.0</version>
 				<configuration>
-					<nunitHome>${env.ProgramFiles}\NUnit-2.5.8.10295</nunitHome>
+                   <nunitHome>${env.ProgramFiles}\NUnit-2.5.8.10295</nunitHome>
 				</configuration>
 			</plugin>
             <plugin>

--- a/jni4net.tested.j/jni4net.tested.j.iml
+++ b/jni4net.tested.j/jni4net.tested.j.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module MavenProjectsManager.isMavenModule="true" org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" relativePaths="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5" inherit-compiler-output="false">
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
@@ -10,7 +10,7 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="jni4net.j" />
+    <orderEntry type="library" name="Maven: log4j:log4j:1.2.17" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.5" level="project" />
   </component>
 </module>
-

--- a/jni4net.tested.n/jni4net.tested.n.iml
+++ b/jni4net.tested.n/jni4net.tested.n.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module MavenProjectsManager.isMavenModule="true" org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" relativePaths="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5" inherit-compiler-output="false">
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
@@ -10,7 +10,7 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="jni4net.j" />
+    <orderEntry type="library" name="Maven: log4j:log4j:1.2.17" level="project" />
     <orderEntry type="module" module-name="jni4net.tested.j" />
   </component>
 </module>
-

--- a/pom.xml
+++ b/pom.xml
@@ -28,14 +28,19 @@
         <repository>
             <id>net.sf.jni4net</id>
             <name>jni4net release repository</name>
-            <url>http://jni4net.googlecode.com/svn/mvnrepo</url>
+            <url>https://raw.githubusercontent.com/jni4net/jni4net.github.io/master/mvnrepo</url>
+        </repository>
+        <repository>
+            <id>central</id>
+            <name>Maven Repository Switchboard</name>
+            <url>http://repo1.maven.org/maven2</url>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>net.sf.jni4net</id>
             <name>jni4net release repository</name>
-            <url>http://jni4net.googlecode.com/svn/mvnrepo</url>
+            <url>https://raw.githubusercontent.com/jni4net/jni4net.github.io/master/mvnrepo</url>
         </pluginRepository>
     </pluginRepositories>
     <licenses>
@@ -49,12 +54,12 @@
         </license>
     </licenses>
     <distributionManagement>
-        <downloadUrl>http://jni4net.googlecode.com/svn/mvnrepo</downloadUrl>
+        <downloadUrl>https://raw.githubusercontent.com/jni4net/jni4net.github.io/master/mvnrepo</downloadUrl>
         <repository>
             <uniqueVersion>false</uniqueVersion>
             <id>net.sf.jni4net-upload</id>
             <name>jni4net release repository</name>
-            <url>svn:https://jni4net.googlecode.com/svn/mvnrepo</url>
+            <url>svn:https://jni4net.github.io/mvnrepo</url>
         </repository>
     </distributionManagement>
     <build>

--- a/tools/keys/gennetkey.cmd
+++ b/tools/keys/gennetkey.cmd
@@ -1,2 +1,1 @@
-if not exist "%~dp0/jni4net.snk" "%ProgramFiles%\Microsoft SDKs\Windows\v7.0A\Bin\sn.exe" -k "%~dp0/jni4net.snk"
-if not exist "%~dp0/jni4net.snk" "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v7.0A\Bin\sn.exe" -k "%~dp0/jni4net.snk"
+if not exist "%~dp0/jni4net.snk" "%C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7 Tools\sn.exe" -k "%~dp0/jni4net.snk"

--- a/tools/loadTools.cmd
+++ b/tools/loadTools.cmd
@@ -1,7 +1,7 @@
 @echo off
 mkdir %~dp0\lib
-java -cp %~dp0/loader Loader http://jni4net.googlecode.com/svn/tools/lib/ %~dp0/lib/ ant.jar ant-launcher.jar jacobe.jar junit.jar classworlds-1.1.jar maven-2.0.9-uber.jar nunit.framework-2.5.8.10295.dll
-java -cp %~dp0/loader Loader http://jni4net.googlecode.com/svn/mvnrepo/net/sf/jni4net/selvin.exportdll/0.2.6.0/ %~dp0/lib/ selvin.exportdll-0.2.6.0.dll
-move /y %~dp0\lib\selvin.exportdll-0.2.6.0.dll %~dp0\lib\selvin.exportdll-0.2.6.0.exe
-java -cp %~dp0/loader Loader http://jni4net.googlecode.com/svn/mvnrepo/net/sf/jni4net/selvin.exportdllattribute/0.2.6.0/ %~dp0/lib/ selvin.exportdllattribute-0.2.6.0.dll
+java -cp %~dp0/loader Loader https://raw.githubusercontent.com/jni4net/jni4net.github.io/master/tools/libs/ %~dp0/lib/ ant.jar ant-launcher.jar jacobe.jar junit.jar classworlds-1.1.jar maven-2.0.9-uber.jar nunit.framework-2.5.8.10295.dll
+java -cp %~dp0/loader Loader https://raw.githubusercontent.com/jni4net/jni4net.github.io/master/mvnrepo/net/sf/jni4net/selvin.exportdll/0.2.5.0/ %~dp0/lib/ selvin.exportdll-0.2.5.0.dll
+java -cp %~dp0/loader Loader https://raw.githubusercontent.com/jni4net/jni4net.github.io/master/mvnrepo/net/sf/jni4net/selvin.exportdllattribute/0.2.5.0/ %~dp0/lib/ selvin.exportdllattribute-0.2.5.0.dll
 copy /y %~dp0\lib\nunit.framework-2.5.8.10295.dll %~dp0\lib\nunit.framework.dll
+


### PR DESCRIPTION
Slight modifications are introduced to the class net.sf.jni4net.CLRLoader. In the method init(File), we use apache Logger to trace error messages instead of using the system standard output.

Changed files:
- 3 java files are changed:
               jni4net.j/src/main/java/net/sf/jni4net/CLRLoader.java
               jni4net.j/src/main/java/java_/lang/reflect/TypeVariable_.java
              jni4net.j/src/main/java/java_/lang/reflect/GenericDeclaration_.java)
-  pom.xml (of the main project and its submodules)
- *.csproj (change dependencies version from 0.2.6.0 to 0.2.5.0)
- loadTools.cmd
- gennetkey.cmd

NB: All .iml and .xml files are changes automatically (when executing the command 'mvnassembly.cmd')
