### PR TITLE
modify jni4net.j to use apache Logger instead of the standard system output

### DIFF
--- a/jni4net.j/pom.xml
+++ b/jni4net.j/pom.xml
@@ -13,6 +13,11 @@
     <name>jni4net Java</name>
     <dependencies>
         <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.5</version>

--- a/jni4net.j/src/main/java/java_/lang/reflect/GenericDeclaration_.java
+++ b/jni4net.j/src/main/java/java_/lang/reflect/GenericDeclaration_.java
@@ -27,7 +27,7 @@ public final class GenericDeclaration_ {
 
 //<generated-proxy>
 @net.sf.jni4net.attributes.ClrProxy
-class __GenericDeclaration extends system.Object implements java.lang.reflect.GenericDeclaration {
+abstract class __GenericDeclaration extends system.Object implements java.lang.reflect.GenericDeclaration {
     
     protected __GenericDeclaration(net.sf.jni4net.inj.INJEnv __env, long __handle) {
             super(__env, __handle);

--- a/jni4net.j/src/main/java/java_/lang/reflect/TypeVariable_.java
+++ b/jni4net.j/src/main/java/java_/lang/reflect/TypeVariable_.java
@@ -27,7 +27,7 @@ public final class TypeVariable_ {
 
 //<generated-proxy>
 @net.sf.jni4net.attributes.ClrProxy
-class __TypeVariable extends system.Object implements java.lang.reflect.TypeVariable {
+abstract class __TypeVariable extends system.Object implements java.lang.reflect.TypeVariable {
     
     protected __TypeVariable(net.sf.jni4net.inj.INJEnv __env, long __handle) {
             super(__env, __handle);

--- a/jni4net.j/src/main/java/net/sf/jni4net/CLRLoader.java
+++ b/jni4net.j/src/main/java/net/sf/jni4net/CLRLoader.java
@@ -16,6 +16,7 @@ import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Properties;
+import org.apache.log4j.Logger;
 
 /**
  * @author Pavel Savara (original)
@@ -23,6 +24,8 @@ import java.util.Properties;
 class CLRLoader {
 	private static String version;
     private static String platform;
+
+	private static Logger logger = Logger.getLogger(CLRLoader.class);
 
     public static void 	init(File fileOrDirectory) throws IOException {
 		if (!Bridge.isRegistered) {
@@ -36,13 +39,16 @@ class CLRLoader {
                 System.load(file);
 				final int res = Bridge.initDotNet();
 				if (res != 0) {
-					System.err.println("Can't initialize jni4net Bridge from " + file);
-					throw new net.sf.jni4net.inj.INJException("Can't initialize jni4net Bridge. Code:"+res);
+					//System.err.println("Can't initialize jni4net Bridge from " + file);
+					//throw new net.sf.jni4net.inj.INJException("Can't initialize jni4net Bridge. Code:"+res);
+					logger.error("Can't initialize jni4net Bridge from " + file);
+					logger.error("Can't initialize jni4net Bridge. Code: "+ res);
 				}
 				Bridge.isRegistered = true;
 			} catch (Throwable th) {
-				System.err.println("Can't initialize jni4net Bridge" + th.getMessage());
-				throw new net.sf.jni4net.inj.INJException("Can't initialize jni4net Bridge", th);
+				//System.err.println("Can't initialize jni4net Bridge" + th.getMessage());
+				//throw new net.sf.jni4net.inj.INJException("Can't initialize jni4net Bridge", th);
+				logger.error("Can't initialize jni4net Bridge: " + th.getMessage());
 			}
 		}
 	}


### PR DESCRIPTION
Slight modifications are introduced to the class net.sf.jni4net.CLRLoader. In the method init(File), we use apache Logger to trace error messages instead of using the system standard output.

Changed files:

- 3 java files are changed:
        jni4net.j/src/main/java/net/sf/jni4net/CLRLoader.java
        jni4net.j/src/main/java/java_/lang/reflect/TypeVariable_.java
        jni4net.j/src/main/java/java_/lang/reflect/GenericDeclaration_.java)
- pom.xml (of the main project and its submodules)