### PR TITLE
use Apache Logger for error messages instead of the system standard output

### DIFF
--- a/jni4net.j/pom.xml
+++ b/jni4net.j/pom.xml
@@ -13,6 +13,11 @@
     <name>jni4net Java</name>
     <dependencies>
         <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.5</version>

--- a/jni4net.j/src/main/java/net/sf/jni4net/CLRLoader.java
+++ b/jni4net.j/src/main/java/net/sf/jni4net/CLRLoader.java
@@ -7,8 +7,6 @@ This content is released under the (http://opensource.org/licenses/MIT) MIT Lice
 
 package net.sf.jni4net;
 
-import system.NotSupportedException;
-
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
@@ -17,12 +15,16 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Properties;
 
+import org.apache.log4j.Logger;
+
 /**
  * @author Pavel Savara (original)
  */
 class CLRLoader {
 	private static String version;
     private static String platform;
+
+	private static Logger logger = Logger.getLogger(CLRLoader.class);
 
     public static void 	init(File fileOrDirectory) throws IOException {
 		if (!Bridge.isRegistered) {
@@ -36,12 +38,14 @@ class CLRLoader {
                 System.load(file);
 				final int res = Bridge.initDotNet();
 				if (res != 0) {
-					System.err.println("Can't initialize jni4net Bridge from " + file);
-					throw new net.sf.jni4net.inj.INJException("Can't initialize jni4net Bridge. Code:"+res);
+					//System.err.println("Can't initialize jni4net Bridge from " + file);
+					logger.error("Can't initialize jni4net Bridge from " + file);
+					throw new net.sf.jni4net.inj.INJException("Can't initialize jni4net Bridge. Code: "+res);
 				}
 				Bridge.isRegistered = true;
 			} catch (Throwable th) {
-				System.err.println("Can't initialize jni4net Bridge" + th.getMessage());
+				//System.err.println("Can't initialize jni4net Bridge" + th.getMessage());
+				logger.error("Can't initialize jni4net Bridge: " + th.getMessage());
 				throw new net.sf.jni4net.inj.INJException("Can't initialize jni4net Bridge", th);
 			}
 		}


### PR DESCRIPTION
Slight modifications are introduced to the class net.sf.jni4net.CLRLoader. In the method init(File), we use apache Logger to trace error messages instead of using the system standard output.

