### PR TITLE
Fix jni4net 0.8.8.0 and use apache Logger for the class CLRLoader

### DIFF
--- a/jni4net.j/pom.xml
+++ b/jni4net.j/pom.xml
@@ -13,6 +13,11 @@
     <name>jni4net Java</name>
     <dependencies>
         <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.5</version>

--- a/jni4net.j/src/main/java/net/sf/jni4net/CLRLoader.java
+++ b/jni4net.j/src/main/java/net/sf/jni4net/CLRLoader.java
@@ -7,8 +7,6 @@ This content is released under the (http://opensource.org/licenses/MIT) MIT Lice
 
 package net.sf.jni4net;
 
-import system.NotSupportedException;
-
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
@@ -17,12 +15,16 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Properties;
 
+import org.apache.log4j.Logger;
+
 /**
  * @author Pavel Savara (original)
  */
 class CLRLoader {
 	private static String version;
     private static String platform;
+
+	private static Logger logger = Logger.getLogger(CLRLoader.class);
 
     public static void 	init(File fileOrDirectory) throws IOException {
 		if (!Bridge.isRegistered) {
@@ -36,12 +38,14 @@ class CLRLoader {
                 System.load(file);
 				final int res = Bridge.initDotNet();
 				if (res != 0) {
-					System.err.println("Can't initialize jni4net Bridge from " + file);
-					throw new net.sf.jni4net.inj.INJException("Can't initialize jni4net Bridge. Code:"+res);
+					//System.err.println("Can't initialize jni4net Bridge from " + file);
+					logger.error("Can't initialize jni4net Bridge from " + file);
+					throw new net.sf.jni4net.inj.INJException("Can't initialize jni4net Bridge. Code: "+res);
 				}
 				Bridge.isRegistered = true;
 			} catch (Throwable th) {
-				System.err.println("Can't initialize jni4net Bridge" + th.getMessage());
+				//System.err.println("Can't initialize jni4net Bridge" + th.getMessage());
+				logger.error("Can't initialize jni4net Bridge: " + th.getMessage());
 				throw new net.sf.jni4net.inj.INJException("Can't initialize jni4net Bridge", th);
 			}
 		}

--- a/jni4net.n.w32.v20/pom.xml
+++ b/jni4net.n.w32.v20/pom.xml
@@ -21,14 +21,14 @@
         <dependency>
             <groupId>net.sf.jni4net</groupId>
             <artifactId>selvin.exportdllattribute</artifactId>
-            <version>0.2.6.0</version>
+            <version>0.2.5.0</version>
             <type>dotnet:library</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.sf.jni4net</groupId>
             <artifactId>selvin.exportdll</artifactId>
-            <version>0.2.6.0</version>
+            <version>0.2.5.0</version>
             <type>dotnet:library</type>
             <scope>provided</scope>
         </dependency>
@@ -71,18 +71,18 @@
                         <configuration>
                             <tasks>
                                 <resolveArtifact property="exportdll" groupId="net.sf.jni4net"
-                                                 artifactId="selvin.exportdll" version="0.2.6.0"
+                                                 artifactId="selvin.exportdll" version="0.2.5.0"
                                                  type="dotnet:library"/>
                                 <resolveArtifact property="exportdllattribute" groupId="net.sf.jni4net"
-                                                 artifactId="selvin.exportdllattribute" version="0.2.6.0"
+                                                 artifactId="selvin.exportdllattribute" version="0.2.5.0"
                                                  type="dotnet:library"/>
-                                <copy file="${exportdll}" tofile="target/tool/selvin.exportdll-0.2.6.0.exe"/>
+                                <copy file="${exportdll}" tofile="target/tool/selvin.exportdll-0.2.5.0.exe"/>
                                 <copy file="${exportdllattribute}" todir="target/tool"/>
                                 <exec executable="cmd.exe" failonerror="false" dir="target">
-                                    <arg value="/c tool\selvin.exportdll-0.2.6.0.exe jni4net.n.w32.v20-${jni4net.version}.dll &quot;%ProgramFiles(x86)%\Microsoft SDKs\Windows\v8.0A\Bin\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v2.0.50727\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x32"/>
+                                    <arg value="/c tool\selvin.exportdll-0.2.5.0.exe jni4net.n.w32.v20-${jni4net.version}.dll &quot;%ProgramFiles(x86)%\Microsoft SDKs\Windows\v8.0A\Bin\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v2.0.50727\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x32"/>
                                 </exec>
                                 <exec executable="cmd.exe" failonerror="false" dir="target">
-                                    <arg value="/c tool\selvin.exportdll-0.2.6.0.exe jni4net.n.w32.v20-${jni4net.version}.dll &quot;%ProgramFiles%\Microsoft SDKs\Windows\v8.0A\Bin\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v2.0.50727\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x32"/>
+                                    <arg value="/c tool\selvin.exportdll-0.2.5.0.exe jni4net.n.w32.v20-${jni4net.version}.dll &quot;%ProgramFiles%\Microsoft SDKs\Windows\v8.0A\Bin\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v2.0.50727\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x32"/>
                                 </exec>
                             </tasks>
                         </configuration>

--- a/jni4net.n.w32.v20/src/jni4net.n.w32.v20.csproj
+++ b/jni4net.n.w32.v20/src/jni4net.n.w32.v20.csproj
@@ -60,9 +60,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="selvin.exportdllattribute-0.2.6.0, Version=0.0.0.0, Culture=neutral, PublicKeyToken=57baad0f7b3885b0, processorArchitecture=MSIL">
+    <Reference Include="selvin.exportdllattribute-0.2.5.0, Version=0.0.0.0, Culture=neutral, PublicKeyToken=57baad0f7b3885b0, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\tools\lib\selvin.exportdllattribute-0.2.6.0.dll</HintPath>
+      <HintPath>..\..\tools\lib\selvin.exportdllattribute-0.2.5.0.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -101,7 +101,7 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent>"$(SolutionDir)\tools\lib\selvin.exportdll-0.2.6.0.exe" "$(TargetPath)" "%25ProgramFiles%25\Microsoft SDKs\Windows\v7.0A\Bin\ildasm.exe" "%25windir%25\Microsoft.NET\Framework\v2.0.50727\ilasm.exe" "$(SolutionDir)/tools/keys/jni4net.snk" "$(SolutionDir)/tools/keys/jni4net.snk" /Debug /x32</PostBuildEvent>
+    <PostBuildEvent>"$(SolutionDir)\tools\lib\selvin.exportdll-0.2.5.0.exe" "$(TargetPath)" "%25ProgramFiles%25\Microsoft SDKs\Windows\v7.0A\Bin\ildasm.exe" "%25windir%25\Microsoft.NET\Framework\v2.0.50727\ilasm.exe" "$(SolutionDir)/tools/keys/jni4net.snk" "$(SolutionDir)/tools/keys/jni4net.snk" /Debug /x32</PostBuildEvent>
     <PreBuildEvent>if not exist $(OutDir)\build-sources\generated-sources\META-INF mkdir $(OutDir)\build-sources\generated-sources\META-INF\
 echo [assembly: System.Reflection.AssemblyVersion("0.8.8.0")] &gt; $(OutDir)\build-sources\generated-sources\META-INF\AssemblyInfo.cs
 if not exist $(SolutionDir)\tools\keys\jni4net.snk "%25ProgramFiles%25\Microsoft SDKs\Windows\v7.0A\bin\sn.exe" -k $(SolutionDir)\tools\keys\jni4net.snk

--- a/jni4net.n.w32.v40/pom.xml
+++ b/jni4net.n.w32.v40/pom.xml
@@ -21,14 +21,14 @@
         <dependency>
             <groupId>net.sf.jni4net</groupId>
             <artifactId>selvin.exportdllattribute</artifactId>
-            <version>0.2.6.0</version>
+            <version>0.2.5.0</version>
             <type>dotnet:library</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.sf.jni4net</groupId>
             <artifactId>selvin.exportdll</artifactId>
-            <version>0.2.6.0</version>
+            <version>0.2.5.0</version>
             <type>dotnet:library</type>
             <scope>provided</scope>
         </dependency>
@@ -70,18 +70,18 @@
                         <configuration>
                             <tasks>
                                 <resolveArtifact property="exportdll" groupId="net.sf.jni4net"
-                                                 artifactId="selvin.exportdll" version="0.2.6.0"
+                                                 artifactId="selvin.exportdll" version="0.2.5.0"
                                                  type="dotnet:library"/>
                                 <resolveArtifact property="exportdllattribute" groupId="net.sf.jni4net"
-                                                 artifactId="selvin.exportdllattribute" version="0.2.6.0"
+                                                 artifactId="selvin.exportdllattribute" version="0.2.5.0"
                                                  type="dotnet:library"/>
-                                <copy file="${exportdll}" tofile="target/tool/selvin.exportdll-0.2.6.0.exe"/>
+                                <copy file="${exportdll}" tofile="target/tool/selvin.exportdll-0.2.5.0.exe"/>
                                 <copy file="${exportdllattribute}" todir="target/tool"/>
                                 <exec executable="cmd.exe" failonerror="false" dir="target">
-                                    <arg value="/c tool\selvin.exportdll-0.2.6.0.exe jni4net.n.w32.v40-${jni4net.version}.dll &quot;%ProgramFiles(x86)%\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x32"/>
+                                    <arg value="/c tool\selvin.exportdll-0.2.5.0.exe jni4net.n.w32.v40-${jni4net.version}.dll &quot;%ProgramFiles(x86)%\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x32"/>
                                 </exec>
                                 <exec executable="cmd.exe" failonerror="false" dir="target">
-                                    <arg value="/c tool\selvin.exportdll-0.2.6.0.exe jni4net.n.w32.v40-${jni4net.version}.dll &quot;%ProgramFiles%\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x32"/>
+                                    <arg value="/c tool\selvin.exportdll-0.2.5.0.exe jni4net.n.w32.v40-${jni4net.version}.dll &quot;%ProgramFiles%\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x32"/>
                                 </exec>
                             </tasks>
                         </configuration>

--- a/jni4net.n.w32.v40/src/jni4net.n.w32.v40.csproj
+++ b/jni4net.n.w32.v40/src/jni4net.n.w32.v40.csproj
@@ -60,9 +60,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="selvin.exportdllattribute-0.2.6.0, Version=0.0.0.0, Culture=neutral, PublicKeyToken=57baad0f7b3885b0, processorArchitecture=MSIL">
+    <Reference Include="selvin.exportdllattribute-0.2.5.0, Version=0.0.0.0, Culture=neutral, PublicKeyToken=57baad0f7b3885b0, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\tools\lib\selvin.exportdllattribute-0.2.6.0.dll</HintPath>
+      <HintPath>..\..\tools\lib\selvin.exportdllattribute-0.2.5.0.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -101,7 +101,7 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent>"$(SolutionDir)\tools\lib\selvin.exportdll-0.2.6.0.exe" "$(TargetPath)" "%25ProgramFiles%25\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\ildasm.exe" "%25windir%25\Microsoft.NET\Framework\v4.0.30319\ilasm.exe" "$(SolutionDir)/tools/keys/jni4net.snk" "$(SolutionDir)/tools/keys/jni4net.snk" /Debug /x32</PostBuildEvent>
+    <PostBuildEvent>"$(SolutionDir)\tools\lib\selvin.exportdll-0.2.5.0.exe" "$(TargetPath)" "%25ProgramFiles%25\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\ildasm.exe" "%25windir%25\Microsoft.NET\Framework\v4.0.30319\ilasm.exe" "$(SolutionDir)/tools/keys/jni4net.snk" "$(SolutionDir)/tools/keys/jni4net.snk" /Debug /x32</PostBuildEvent>
     <PreBuildEvent>if not exist $(OutDir)\build-sources\generated-sources\META-INF mkdir $(OutDir)\build-sources\generated-sources\META-INF\
 echo [assembly: System.Reflection.AssemblyVersion("0.8.8.0")] &gt; $(OutDir)\build-sources\generated-sources\META-INF\AssemblyInfo.cs
 if not exist $(SolutionDir)\tools\keys\jni4net.snk "%25ProgramFiles%25\Microsoft SDKs\Windows\v7.0A\bin\sn.exe" -k $(SolutionDir)\tools\keys\jni4net.snk

--- a/jni4net.n.w64.v20/pom.xml
+++ b/jni4net.n.w64.v20/pom.xml
@@ -21,14 +21,14 @@
         <dependency>
             <groupId>net.sf.jni4net</groupId>
             <artifactId>selvin.exportdllattribute</artifactId>
-            <version>0.2.6.0</version>
+            <version>0.2.5.0</version>
             <type>dotnet:library</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.sf.jni4net</groupId>
             <artifactId>selvin.exportdll</artifactId>
-            <version>0.2.6.0</version>
+            <version>0.2.5.0</version>
             <type>dotnet:library</type>
             <scope>provided</scope>
         </dependency>
@@ -71,18 +71,18 @@
                         <configuration>
                             <tasks>
                                 <resolveArtifact property="exportdll" groupId="net.sf.jni4net"
-                                                 artifactId="selvin.exportdll" version="0.2.6.0"
+                                                 artifactId="selvin.exportdll" version="0.2.5.0"
                                                  type="dotnet:library"/>
                                 <resolveArtifact property="exportdllattribute" groupId="net.sf.jni4net"
-                                                 artifactId="selvin.exportdllattribute" version="0.2.6.0"
+                                                 artifactId="selvin.exportdllattribute" version="0.2.5.0"
                                                  type="dotnet:library"/>
-                                <copy file="${exportdll}" tofile="target/tool/selvin.exportdll-0.2.6.0.exe"/>
+                                <copy file="${exportdll}" tofile="target/tool/selvin.exportdll-0.2.5.0.exe"/>
                                 <copy file="${exportdllattribute}" todir="target/tool"/>
                                 <exec executable="cmd.exe" failonerror="false" dir="target">
-                                    <arg value="/c tool\selvin.exportdll-0.2.6.0.exe jni4net.n.w64.v20-${jni4net.version}.dll &quot;%ProgramFiles(x86)%\Microsoft SDKs\Windows\v8.0A\Bin\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v2.0.50727\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x64"/>
+                                    <arg value="/c tool\selvin.exportdll-0.2.5.0.exe jni4net.n.w64.v20-${jni4net.version}.dll &quot;%ProgramFiles(x86)%\Microsoft SDKs\Windows\v8.0A\Bin\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v2.0.50727\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x64"/>
                                 </exec>
                                 <exec executable="cmd.exe" failonerror="false" dir="target">
-                                    <arg value="/c tool\selvin.exportdll-0.2.6.0.exe jni4net.n.w64.v20-${jni4net.version}.dll &quot;%ProgramFiles%\Microsoft SDKs\Windows\v8.0A\Bin\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v2.0.50727\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x64"/>
+                                    <arg value="/c tool\selvin.exportdll-0.2.5.0.exe jni4net.n.w64.v20-${jni4net.version}.dll &quot;%ProgramFiles%\Microsoft SDKs\Windows\v8.0A\Bin\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v2.0.50727\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x64"/>
                                 </exec>
                             </tasks>
                         </configuration>

--- a/jni4net.n.w64.v20/src/jni4net.n.w64.v20.csproj
+++ b/jni4net.n.w64.v20/src/jni4net.n.w64.v20.csproj
@@ -60,9 +60,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="selvin.exportdllattribute-0.2.6.0, Version=0.0.0.0, Culture=neutral, PublicKeyToken=57baad0f7b3885b0, processorArchitecture=MSIL">
+    <Reference Include="selvin.exportdllattribute-0.2.5.0, Version=0.0.0.0, Culture=neutral, PublicKeyToken=57baad0f7b3885b0, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\tools\lib\selvin.exportdllattribute-0.2.6.0.dll</HintPath>
+      <HintPath>..\..\tools\lib\selvin.exportdllattribute-0.2.5.0.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -101,7 +101,7 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent>"$(SolutionDir)\tools\lib\selvin.exportdll-0.2.6.0.exe" "$(TargetPath)" "%25ProgramFiles%25\Microsoft SDKs\Windows\v7.0A\Bin\ildasm.exe" "%25windir%25\Microsoft.NET\Framework\v2.0.50727\ilasm.exe" "$(SolutionDir)/tools/keys/jni4net.snk" /Debug /x64</PostBuildEvent>
+    <PostBuildEvent>"$(SolutionDir)\tools\lib\selvin.exportdll-0.2.5.0.exe" "$(TargetPath)" "%25ProgramFiles%25\Microsoft SDKs\Windows\v7.0A\Bin\ildasm.exe" "%25windir%25\Microsoft.NET\Framework\v2.0.50727\ilasm.exe" "$(SolutionDir)/tools/keys/jni4net.snk" /Debug /x64</PostBuildEvent>
     <PreBuildEvent>if not exist $(OutDir)\build-sources\generated-sources\META-INF mkdir $(OutDir)\build-sources\generated-sources\META-INF\
 echo [assembly: System.Reflection.AssemblyVersion("0.8.8.0")] &gt; $(OutDir)\build-sources\generated-sources\META-INF\AssemblyInfo.cs
 if not exist $(SolutionDir)\tools\keys\jni4net.snk "%25ProgramFiles%25\Microsoft SDKs\Windows\v7.0A\bin\sn.exe" -k $(SolutionDir)\tools\keys\jni4net.snk

--- a/jni4net.n.w64.v40/pom.xml
+++ b/jni4net.n.w64.v40/pom.xml
@@ -21,14 +21,14 @@
         <dependency>
             <groupId>net.sf.jni4net</groupId>
             <artifactId>selvin.exportdllattribute</artifactId>
-            <version>0.2.6.0</version>
+            <version>0.2.5.0</version>
             <type>dotnet:library</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.sf.jni4net</groupId>
             <artifactId>selvin.exportdll</artifactId>
-            <version>0.2.6.0</version>
+            <version>0.2.5.0</version>
             <type>dotnet:library</type>
             <scope>provided</scope>
         </dependency>
@@ -70,18 +70,18 @@
                         <configuration>
                             <tasks>
                                 <resolveArtifact property="exportdll" groupId="net.sf.jni4net"
-                                                 artifactId="selvin.exportdll" version="0.2.6.0"
+                                                 artifactId="selvin.exportdll" version="0.2.5.0"
                                                  type="dotnet:library"/>
                                 <resolveArtifact property="exportdllattribute" groupId="net.sf.jni4net"
-                                                 artifactId="selvin.exportdllattribute" version="0.2.6.0"
+                                                 artifactId="selvin.exportdllattribute" version="0.2.5.0"
                                                  type="dotnet:library"/>
-                                <copy file="${exportdll}" tofile="target/tool/selvin.exportdll-0.2.6.0.exe"/>
+                                <copy file="${exportdll}" tofile="target/tool/selvin.exportdll-0.2.5.0.exe"/>
                                 <copy file="${exportdllattribute}" todir="target/tool"/>
                                 <exec executable="cmd.exe" failonerror="false" dir="target">
-                                    <arg value="/c tool\selvin.exportdll-0.2.6.0.exe jni4net.n.w64.v40-${jni4net.version}.dll &quot;%ProgramFiles(x86)%\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x64"/>
+                                    <arg value="/c tool\selvin.exportdll-0.2.5.0.exe jni4net.n.w64.v40-${jni4net.version}.dll &quot;%ProgramFiles(x86)%\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x64"/>
                                 </exec>
                                 <exec executable="cmd.exe" failonerror="false" dir="target">
-                                    <arg value="/c tool\selvin.exportdll-0.2.6.0.exe jni4net.n.w64.v40-${jni4net.version}.dll &quot;%ProgramFiles%\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x64"/>
+                                    <arg value="/c tool\selvin.exportdll-0.2.5.0.exe jni4net.n.w64.v40-${jni4net.version}.dll &quot;%ProgramFiles%\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\ildasm.exe&quot; &quot;%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\ilasm.exe&quot; &quot;${basedir}/../tools/keys/jni4net.snk&quot; /Release /x64"/>
                                 </exec>
                             </tasks>
                         </configuration>

--- a/jni4net.n.w64.v40/src/jni4net.n.w64.v40.csproj
+++ b/jni4net.n.w64.v40/src/jni4net.n.w64.v40.csproj
@@ -60,9 +60,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="selvin.exportdllattribute-0.2.6.0, Version=0.0.0.0, Culture=neutral, PublicKeyToken=57baad0f7b3885b0, processorArchitecture=MSIL">
+    <Reference Include="selvin.exportdllattribute-0.2.5.0, Version=0.0.0.0, Culture=neutral, PublicKeyToken=57baad0f7b3885b0, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\tools\lib\selvin.exportdllattribute-0.2.6.0.dll</HintPath>
+      <HintPath>..\..\tools\lib\selvin.exportdllattribute-0.2.5.0.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -101,7 +101,7 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent>"$(SolutionDir)\tools\lib\selvin.exportdll-0.2.6.0.exe" "$(TargetPath)" "%25ProgramFiles%25\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\ildasm.exe" "%25windir%25\Microsoft.NET\Framework\v4.0.30319\ilasm.exe" "$(SolutionDir)/tools/keys/jni4net.snk" /Debug /x64</PostBuildEvent>
+    <PostBuildEvent>"$(SolutionDir)\tools\lib\selvin.exportdll-0.2.5.0.exe" "$(TargetPath)" "%25ProgramFiles%25\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\ildasm.exe" "%25windir%25\Microsoft.NET\Framework\v4.0.30319\ilasm.exe" "$(SolutionDir)/tools/keys/jni4net.snk" /Debug /x64</PostBuildEvent>
     <PreBuildEvent>if not exist $(OutDir)\build-sources\generated-sources\META-INF mkdir $(OutDir)\build-sources\generated-sources\META-INF\
 echo [assembly: System.Reflection.AssemblyVersion("0.8.8.0")] &gt; $(OutDir)\build-sources\generated-sources\META-INF\AssemblyInfo.cs
 if not exist $(SolutionDir)\tools\keys\jni4net.snk "%25ProgramFiles%25\Microsoft SDKs\Windows\v7.0A\bin\sn.exe" -k $(SolutionDir)\tools\keys\jni4net.snk

--- a/pom.xml
+++ b/pom.xml
@@ -28,14 +28,14 @@
         <repository>
             <id>net.sf.jni4net</id>
             <name>jni4net release repository</name>
-            <url>http://jni4net.googlecode.com/svn/mvnrepo</url>
+            <url>https://raw.githubusercontent.com/jni4net/jni4net.github.io/master/mvnrepo</url>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>net.sf.jni4net</id>
             <name>jni4net release repository</name>
-            <url>http://jni4net.googlecode.com/svn/mvnrepo</url>
+            <url>https://raw.githubusercontent.com/jni4net/jni4net.github.io/master/mvnrepo</url>
         </pluginRepository>
     </pluginRepositories>
     <licenses>
@@ -49,12 +49,12 @@
         </license>
     </licenses>
     <distributionManagement>
-        <downloadUrl>http://jni4net.googlecode.com/svn/mvnrepo</downloadUrl>
+        <downloadUrl>https://raw.githubusercontent.com/jni4net/jni4net.github.io/master/mvnrepo</downloadUrl>
         <repository>
             <uniqueVersion>false</uniqueVersion>
             <id>net.sf.jni4net-upload</id>
             <name>jni4net release repository</name>
-            <url>svn:https://jni4net.googlecode.com/svn/mvnrepo</url>
+            <url>svn:https://jni4net.github.io/mvnrepo</url>
         </repository>
     </distributionManagement>
     <build>

--- a/tools/keys/gennetkey.cmd
+++ b/tools/keys/gennetkey.cmd
@@ -1,2 +1,1 @@
-if not exist "%~dp0/jni4net.snk" "%ProgramFiles%\Microsoft SDKs\Windows\v7.0A\Bin\sn.exe" -k "%~dp0/jni4net.snk"
-if not exist "%~dp0/jni4net.snk" "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v7.0A\Bin\sn.exe" -k "%~dp0/jni4net.snk"
+if not exist "%~dp0/jni4net.snk" "%C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7 Tools\sn.exe" -k "%~dp0/jni4net.snk"

--- a/tools/loadTools.cmd
+++ b/tools/loadTools.cmd
@@ -1,7 +1,6 @@
 @echo off
 mkdir %~dp0\lib
-java -cp %~dp0/loader Loader http://jni4net.googlecode.com/svn/tools/lib/ %~dp0/lib/ ant.jar ant-launcher.jar jacobe.jar junit.jar classworlds-1.1.jar maven-2.0.9-uber.jar nunit.framework-2.5.8.10295.dll
-java -cp %~dp0/loader Loader http://jni4net.googlecode.com/svn/mvnrepo/net/sf/jni4net/selvin.exportdll/0.2.6.0/ %~dp0/lib/ selvin.exportdll-0.2.6.0.dll
-move /y %~dp0\lib\selvin.exportdll-0.2.6.0.dll %~dp0\lib\selvin.exportdll-0.2.6.0.exe
-java -cp %~dp0/loader Loader http://jni4net.googlecode.com/svn/mvnrepo/net/sf/jni4net/selvin.exportdllattribute/0.2.6.0/ %~dp0/lib/ selvin.exportdllattribute-0.2.6.0.dll
+java -cp %~dp0/loader Loader https://raw.githubusercontent.com/jni4net/jni4net.github.io/master/tools/libs/ %~dp0/lib/ ant.jar ant-launcher.jar jacobe.jar junit.jar classworlds-1.1.jar maven-2.0.9-uber.jar nunit.framework-2.5.8.10295.dll
+java -cp %~dp0/loader Loader https://raw.githubusercontent.com/jni4net/jni4net.github.io/master/mvnrepo/net/sf/jni4net/selvin.exportdll/0.2.5.0/ %~dp0/lib/ selvin.exportdll-0.2.5.0.dll
+java -cp %~dp0/loader Loader https://raw.githubusercontent.com/jni4net/jni4net.github.io/master/mvnrepo/net/sf/jni4net/selvin.exportdllattribute/0.2.5.0/ %~dp0/lib/ selvin.exportdllattribute-0.2.5.0.dll
 copy /y %~dp0\lib\nunit.framework-2.5.8.10295.dll %~dp0\lib\nunit.framework.dll


### PR DESCRIPTION
Slight modifications are introduced to the class net.sf.jni4net.CLRLoader. In the method init(File), we use apache Logger to trace error messages instead of using the system standard output.

Changed files:

3 java files are changed:
jni4net.j/src/main/java/net/sf/jni4net/CLRLoader.java
jni4net.j/src/main/java/java_/lang/reflect/TypeVariable_.java
jni4net.j/src/main/java/java_/lang/reflect/GenericDeclaration_.java)
pom.xml (of the main project and its submodules)
*.csproj (change dependencies version from 0.2.6.0 to 0.2.5.0)
loadTools.cmd
gennetkey.cmd